### PR TITLE
Updated HLDR32

### DIFF
--- a/hldr32/hldr32.inc
+++ b/hldr32/hldr32.inc
@@ -1,3 +1,6 @@
+;HLDR (32 bit)
+;version 1.1
+
 CREATE_ALWAYS                   equ     2
 FILE_WRITE_DATA                 equ     2
 
@@ -24,7 +27,6 @@ struc    mapstk
 endstruc
 
 struc   krncrcstk
-.kVirtualAlloc:          resd 1
 .kLoadLibraryA:          resd 1
 .kGetProcAddress:        resd 1
 .kFlushInstructionCache: resd 1


### PR DESCRIPTION
- fixed bug: code didn't handle NULL OriginalFirstThunk pointer, now uses FirstThunk in that case
- added code to save/restore stack frame pointer (EBX) if loaded file returns to HLDR
- several changes to the code (elimination of branches, code optimizations, etc)
- added version numbers